### PR TITLE
Multiple [ISSUE] text fixed

### DIFF
--- a/python/ts-to-word.py
+++ b/python/ts-to-word.py
@@ -208,10 +208,10 @@ def write_transcribe_text(output_table, sentiment_enabled, analytics_mode, speec
 
         # Then do each word with confidence-level colouring
         text_index = 1
-        live_issue = False
+        live_issue = False        
         for eachWord in segment.segmentConfidence:
             # Are we at the start of an issue?
-            if len(next_issue) > 0:
+            if len(next_issue) > 0 and live_issue == False:
                 if (next_issue["Begin"] == 0) or (next_issue["Begin"] == text_index):
                     # If so, start the highlighting run
                     run = row_cells[COL_CONTENT + content_col_offset].paragraphs[0].add_run(" [ISSUE]")


### PR DESCRIPTION
Fixed Mutliple [ISSUE] text for each word of docx output file.

Below screenshot of output file which is generated using original code.
![original issue](https://user-images.githubusercontent.com/49163967/153130465-9cc1a0a9-d6e3-4b25-b5ab-dec3e1d31b8e.png)

Now below screen shot of output file which is generated by fixing that issue.
![change code issue](https://user-images.githubusercontent.com/49163967/153130684-5b63c74d-e744-4549-ba03-e776e2ee83ff.png)

Explanation:

- I had given input of another wav file and in that file as output in docx file it was giving multiple [ISSUE] text for each word. It's because of issue is starting from **0** character.
- I fixed it by adding live_issue == False in one if condition.